### PR TITLE
No more history

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -50,7 +50,7 @@ class jekyllSearch {
     this.searchField.addEventListener('keyup', () => {
       this.displayResults()
       url.searchParams.set("search", this.searchField.value)
-      window.history.pushState('', '', url.href)
+      window.history.replaceState('', '', url.href)
     })
     this.searchField.addEventListener('keypress', event => {
       if (event.keyCode == 13) {


### PR DESCRIPTION
If use `pushState()`, it will creat many history when change the input box.

Using `replaceState()` can solve the problem.